### PR TITLE
Fix Option2 streaming from vidstreaming.io

### DIFF
--- a/app/src/main/java/com/anistream/xyz/WatchVideo.java
+++ b/app/src/main/java/com/anistream/xyz/WatchVideo.java
@@ -17,6 +17,7 @@ import android.graphics.drawable.Icon;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.os.Handler;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.view.View;
@@ -335,8 +336,14 @@ public class WatchVideo extends AppCompatActivity {
                     // if (currentScraper == scrapers.size()) Use if currentScraper = 0
                     if (currentScraper < 0) { // Use if currentScraper = 1
                         useFallBack();
-                    } else
-                        changingScraper();
+                    } else {
+                        new Handler(context.getMainLooper()).post(new Runnable() {
+                            @Override
+                            public void run() {
+                                changingScraper();
+                            }
+                        });
+                    }
                 }
 
                 host = scrapers.get(currentScraper).getHost();

--- a/app/src/main/java/com/anistream/xyz/scrapers/Option2.java
+++ b/app/src/main/java/com/anistream/xyz/scrapers/Option2.java
@@ -38,7 +38,7 @@ public class Option2 extends Scraper {
         ArrayList<Quality> qualities = new ArrayList<>();
         try {
             String vidStreamUrl = "https:" + gogoAnimePageDocument.getElementsByClass("play-video").get(0).getElementsByTag("iframe").get(0).attr("src");
-            String vidCdnUrl = vidStreamUrl.replace("streaming.php", "streaming.php");
+            String vidCdnUrl = vidStreamUrl.replace("streaming.php", "loadserver.php");
             Document vidCdnPageDocument = Jsoup.connect(vidCdnUrl).get();
             Log.i("vidcdn","vidcdn is "+vidCdnUrl);
             String htmlToParse = vidCdnPageDocument.outerHtml();


### PR DESCRIPTION
This fixes issues related to 'I can't stream anything' and another error where ExoPlayer is accessed from the background thread when the fallback changingScraper() function is called.

I cloned the current master branch and could confirm that 'nothing' could be streamed. I then looked and found that m3u8 links were not found at the vidstreaming streaming.php locations. The links are now found at loadserver.php locations on the site. I modified the replace statement for the URL that has not been used since the last version of Anistream.