### PR TITLE
Fix changingScraper errors (again)

### DIFF
--- a/app/src/main/java/com/anistream/xyz/WatchVideo.java
+++ b/app/src/main/java/com/anistream/xyz/WatchVideo.java
@@ -334,20 +334,22 @@ public class WatchVideo extends AppCompatActivity {
 
                     currentScraper--;
                     // if (currentScraper == scrapers.size()) Use if currentScraper = 0
-                    if (currentScraper < 0) { // Use if currentScraper = 1
-                        useFallBack();
-                    } else {
-                        new Handler(context.getMainLooper()).post(new Runnable() {
-                            @Override
-                            public void run() {
+                    new Handler(context.getMainLooper()).post(new Runnable() {
+                        @Override
+                        public void run() {
+                            if (currentScraper < 0) { // Use if currentScraper = 1
+                                useFallBack();
+                            } else {
                                 changingScraper();
                             }
-                        });
-                    }
+                        }
+                    });
+                } else {
+                    host = scrapers.get(currentScraper).getHost();
+                    currentQuality = 0;
                 }
 
-                host = scrapers.get(currentScraper).getHost();
-                currentQuality = 0;
+
 
             } catch (Exception e1) {
                 e1.printStackTrace();

--- a/app/src/main/java/com/anistream/xyz/scrapers/Option1.java
+++ b/app/src/main/java/com/anistream/xyz/scrapers/Option1.java
@@ -31,7 +31,7 @@ public class Option1 extends Scraper {
         try
         {
             String vidStreamUrl = "https:" + gogoAnimePageDocument.getElementsByClass("play-video").get(0).getElementsByTag("iframe").get(0).attr("src");
-            //String vidCdnUrl = vidStreamUrl.replace("streaming.php", "load.php");
+            vidStreamUrl = vidStreamUrl.replace("streaming.php", "loadserver.php");
 
             Document vidStreamPageDocument = Jsoup.connect(vidStreamUrl).get();
 
@@ -93,7 +93,7 @@ public class Option1 extends Scraper {
 
     @Override
     public String getHost() {
-        return "";
+        return m3u8Link;
     }
 
 }

--- a/app/src/main/java/com/anistream/xyz/scrapers/Option2.java
+++ b/app/src/main/java/com/anistream/xyz/scrapers/Option2.java
@@ -34,7 +34,6 @@ public class Option2 extends Scraper {
     @Override
     public ArrayList<Quality> getQualityUrls()
     {
-
         ArrayList<Quality> qualities = new ArrayList<>();
         try {
             String vidStreamUrl = "https:" + gogoAnimePageDocument.getElementsByClass("play-video").get(0).getElementsByTag("iframe").get(0).attr("src");


### PR DESCRIPTION
The idea of this is to move the step where the new video is loaded (and the old video is accessed) to the main thread where ExoPlayer is to resolve some errors.

My process for testing was to break Option2 and fix Option1. Both Option1 and Option2 now work for vidstreaming.io properly. The changing servers works properly.

useFallback() would also have thrown an error before. This is also fixed in this commit.