### PR TITLE
Fix streaming and anime listing.

### DIFF
--- a/app/src/main/java/com/anistream/xyz/AnimeFragment.java
+++ b/app/src/main/java/com/anistream/xyz/AnimeFragment.java
@@ -101,7 +101,11 @@ public class AnimeFragment extends Fragment {
                     String mAnimenName = mElementAnimeName.text();
                     if (mAnimenName.contains("[email protect  ed]"))
                         mAnimenName = mAnimenName.replace("[email protected]", "IDOLM@STER");
-                    String mlink = searching.select("p[class=name]").select("a").eq(i).attr("abs:href");
+                    String mlink = searching.select("p[class=name]").select("a").eq(i).attr("href");
+                    if(!mlink.startsWith("http")) {
+                        mlink = Constants.url.substring(0, Constants.url.length() - 1) + mlink;
+                    }
+
                     // String imagelink = searching.select("div[class=img]").select("img").eq(2*i).attr("src"); // Use if getting cache error
                     String imagelink = searching.select("div[class=img]").select("img").eq(i).attr("src"); // Use normally
                     String episodeno = searching.select("p[class=episode]").eq(i).text();

--- a/app/src/main/java/com/anistream/xyz/Constants.java
+++ b/app/src/main/java/com/anistream/xyz/Constants.java
@@ -1,6 +1,7 @@
 package com.anistream.xyz;
 
 public class Constants {
-    static String url = "https://3029825460.cobaltmedia.xyz/";
+    //static String url = "https://3029825460.cobaltmedia.xyz/";
+    static String url = "https://www2.gogoanime.video/";
     public static final int APP_VER = 10;
 }

--- a/app/src/main/java/com/anistream/xyz/DataAdapter.java
+++ b/app/src/main/java/com/anistream/xyz/DataAdapter.java
@@ -139,7 +139,7 @@ public class DataAdapter extends RecyclerView.Adapter<DataAdapter.MyViewHolder> 
                     recent.execSQL("delete from anime where EPISODELINK='" + holder.animeuri.toString() + "'");
                     String z = "'" + holder.title.getText().toString().replaceAll("'","''")  + "','" + holder.episodeno.getText().toString() + "','" + holder.animeuri.toString() + "','" + mImageLink.get(position) + "'"; //sql string
                     recent.execSQL("INSERT INTO anime VALUES(" + z + ");");
-                    intent.putExtra("noofepisodes", holder.episodeno.getText().toString().substring(ep + 1, holder.episodeno.getText().toString().length()));
+                    intent.putExtra("noofepisodes", holder.episodeno.getText().toString().substring(ep + 1));
                     intent.putExtra("animename", holder.title.getText().toString());
                     intent.putExtra("imagelink", mImageLink.get(position));
                     intent.putExtra("size", size);

--- a/app/src/main/java/com/anistream/xyz/Quality.java
+++ b/app/src/main/java/com/anistream/xyz/Quality.java
@@ -1,12 +1,24 @@
 package com.anistream.xyz;
 
+import androidx.annotation.NonNull;
+
 public class Quality {
+    public static enum Format {
+        HLS, Progressive
+    }
+
     private String quality;
     private String qualityUrl;
+    private Format format;
 
-    public Quality(String quality, String qualityUrl) {
+    public Quality(Format format, String quality, String qualityUrl) {
         this.quality = quality;
+        this.format = format;
         this.qualityUrl = qualityUrl;
+    }
+
+    public Format getFormat() {
+        return format;
     }
 
     public String getQuality() {
@@ -15,5 +27,11 @@ public class Quality {
 
     public String getQualityUrl() {
         return qualityUrl;
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return String.format("Quality [%s @ %s (%s)]", qualityUrl, quality, format.toString());
     }
 }

--- a/app/src/main/java/com/anistream/xyz/ViewPagerAdapter.java
+++ b/app/src/main/java/com/anistream/xyz/ViewPagerAdapter.java
@@ -17,9 +17,8 @@ public class    ViewPagerAdapter extends FragmentPagerAdapter {
     Fragment fragment=null;
     if(position==0)
     {
-        fragment=AnimeFragment.newInstance(Constants.url+"page-recent-release.html?page=1&type=2");
-
-
+        //fragment=AnimeFragment.newInstance(Constants.url+"page-recent-release.html?page=1&type=2");
+        fragment = AnimeFragment.newInstance("https://ajax.apimovie.xyz/ajax/page-recent-release.html?page=1&type=2");
     }
     else if(position==1)
         fragment=AnimeFragment.newInstance(Constants.url);

--- a/app/src/main/java/com/anistream/xyz/scrapers/Option1.java
+++ b/app/src/main/java/com/anistream/xyz/scrapers/Option1.java
@@ -7,6 +7,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -31,48 +32,20 @@ public class Option1 extends Scraper {
         try
         {
             String vidStreamUrl = "https:" + gogoAnimePageDocument.getElementsByClass("play-video").get(0).getElementsByTag("iframe").get(0).attr("src");
-            //String vidCdnUrl = vidStreamUrl.replace("streaming.php", "load.php");
+            vidStreamUrl = vidStreamUrl.replace("streaming.php", "loadserver.php");
 
             Document vidStreamPageDocument = Jsoup.connect(vidStreamUrl).get();
 
             String html = vidStreamPageDocument.outerHtml();
-            Matcher matcher = urlPattern.matcher(html);
-            String m3u8Link = "";
-            while (matcher.find()) {
-                int matchStart = matcher.start(1);
-                int matchEnd = matcher.end();
-                String link = html.substring(matchStart, matchEnd);
-                if (link.contains("m3u8")) {
-                    m3u8Link = link.substring(0, link.indexOf("'"));
-                    Log.i("ScrapeUrl", m3u8Link);
-                    break;
 
-                }
-            }
-            if(!m3u8Link.equals(""))
-            {
-                Document m3u8Page = Jsoup.connect(m3u8Link).ignoreContentType(true).get();
-                String htmlToParse = m3u8Page.outerHtml();
-                Log.i("html",htmlToParse);
-                Pattern qualityPattern = Pattern.compile("[0-9]{3,4}x[0-9]{3,4}");
-                Pattern m3u8LinkPattern = Pattern.compile("(drive//hls/(\\w)*/(\\w)*.m3u8)|(hls/(\\w)*/(\\w)*.m3u8)|(sub\\.\\d*\\.*\\d*\\.m3u8)|(dub\\.\\d*\\.*\\d*\\.m3u8)");
-                Matcher qualityMatcher = qualityPattern.matcher(htmlToParse);
-                Matcher m3u8LinkMatcher = m3u8LinkPattern.matcher(htmlToParse);
-
-                int index = m3u8Link.lastIndexOf("/hls/");
-
-                String baseUrl = m3u8Link.substring(0, index +"/hls/".length() );
-                Log.i("baseUrl",baseUrl);
-
-                while (qualityMatcher.find() && m3u8LinkMatcher.find()) {
-                    String quality = htmlToParse.substring(qualityMatcher.start(), qualityMatcher.end());
-                    String qualityUrl = baseUrl + htmlToParse.substring(m3u8LinkMatcher.start(), m3u8LinkMatcher.end());
-                    qualities.add(new Quality(quality,qualityUrl) );
-                }
-                Log.i("qualities length",""+qualities.size());
-
-                if(qualities.size()==0)
-                    qualities.add(new Quality("Unknown",m3u8Link));
+            Pattern mp4urlPattern = Pattern.compile("'(.*?goto.php.*?)'");
+            Matcher matcher = mp4urlPattern.matcher(html);
+            if(matcher.find()) {
+                String link = matcher.group(1);
+                qualities.add(new Quality(Quality.Format.Progressive, "Default", link));
+                return qualities;
+            } else {
+                return new ArrayList<>(0);
             }
 
         }
@@ -83,17 +56,12 @@ public class Option1 extends Scraper {
             e.printStackTrace();
 
         }
-        if(qualities.size()==0) {
-
-            qualities.add(new Quality("Unknown", m3u8Link));
-            Log.i("ScrapeUrl", m3u8Link);
-        }
         return qualities;
     }
 
     @Override
     public String getHost() {
-        return "";
+        return m3u8Link;
     }
 
 }

--- a/app/src/main/java/com/anistream/xyz/scrapers/Option2.java
+++ b/app/src/main/java/com/anistream/xyz/scrapers/Option2.java
@@ -88,10 +88,10 @@ public class Option2 extends Scraper {
                     Log.i("ScrapeUrl",qualityUrl);
                     String quality = htmlToParse.substring(qualityMatcher.start(),qualityMatcher.end());
 
-                    qualities.add(new Quality(quality,qualityUrl));
+                    qualities.add(new Quality(Quality.Format.HLS, quality,qualityUrl));
                 }
                 if(qualities.size()==0) {
-                    qualities.add(new Quality("Unknown", m3u8Link));
+                    qualities.add(new Quality(Quality.Format.HLS, "Unknown", m3u8Link));
                     Log.i("ScrapeUrl",m3u8Link);
                 }
             }


### PR DESCRIPTION
The vidstreaming site no longer uses the old m3u8 format. They only support single mp4 links as far as I could tell. I implemented this in the otherwise unused Option1 class while Option2 would be able to handle the old links.

I also added functionality to Quality for different formats to support this change as MP4 is not playable as HLS.

Currently some anime (very few of them) seem to find links that give them ads (and also play ads in the player somehow???). The vast majority of anime works, especially newer ones. I tested old ones like SAO and Bebop and they work fine too.

The search feature sometimes hangs up and times out but works perfectly the vast majority of the time.

Moving the site to a working link for anime discovery changed the format for grabbing dubbed titles. I fixed that as well.