### PR TITLE
Fix some uneccessary fallbacks to webview player and fix support for m3u8 formats.

### DIFF
--- a/app/src/main/java/com/anistream/xyz/Quality.java
+++ b/app/src/main/java/com/anistream/xyz/Quality.java
@@ -2,6 +2,8 @@ package com.anistream.xyz;
 
 import androidx.annotation.NonNull;
 
+import java.util.Map;
+
 public class Quality {
     public static enum Format {
         HLS, Progressive
@@ -10,11 +12,17 @@ public class Quality {
     private String quality;
     private String qualityUrl;
     private Format format;
+    private Map<String, String> headers;
 
-    public Quality(Format format, String quality, String qualityUrl) {
+    public Quality(Format format, String quality, String qualityUrl, Map<String, String> headers) {
         this.quality = quality;
         this.format = format;
         this.qualityUrl = qualityUrl;
+        this.headers = headers;
+    }
+
+    public Map<String, String> getHeaders() {
+        return headers;
     }
 
     public Format getFormat() {

--- a/app/src/main/java/com/anistream/xyz/scrapers/Option1.java
+++ b/app/src/main/java/com/anistream/xyz/scrapers/Option1.java
@@ -42,7 +42,7 @@ public class Option1 extends Scraper {
             Matcher matcher = mp4urlPattern.matcher(html);
             if(matcher.find()) {
                 String link = matcher.group(1);
-                qualities.add(new Quality(Quality.Format.Progressive, "Default", link));
+                qualities.add(new Quality(Quality.Format.Progressive, "No Other Qualities Available (MP4)", link, null));
                 return qualities;
             } else {
                 return new ArrayList<>(0);

--- a/app/src/main/java/com/anistream/xyz/scrapers/Option3.java
+++ b/app/src/main/java/com/anistream/xyz/scrapers/Option3.java
@@ -1,8 +1,9 @@
 package com.anistream.xyz.scrapers;
 
-
 import android.util.Log;
+
 import com.anistream.xyz.Quality;
+
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 
@@ -12,7 +13,7 @@ import java.util.HashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class Option2 extends Scraper {
+public class Option3 extends Scraper {
     private static final Pattern urlPattern = Pattern.compile(
             "(?:^|[\\W])((ht|f)tp(s?):\\/\\/|www\\.)"
                     + "(([\\w\\-]+\\.){1,}?([\\w\\-.~]+\\/?)*"
@@ -21,7 +22,7 @@ public class Option2 extends Scraper {
     //private  static  final Pattern vidCdnM3u8Pattern = Pattern.compile("((sub|dub)\\\\.[0-9]*\\\\.[0-9]*\\\\.m3u8)|(((sub)|(dub))\\.\\d*\\.\\d*\\.m3u8)");
     //private  static  final Pattern vidCdnQualityPattern = Pattern.compile("[0-9]*p");
 
-    public Option2(Document gogoAnimePageDocument) {
+    public Option3(Document gogoAnimePageDocument) {
         this.gogoAnimePageDocument = gogoAnimePageDocument;
     }
 
@@ -38,12 +39,12 @@ public class Option2 extends Scraper {
         ArrayList<Quality> qualities = new ArrayList<>();
         try {
             String vidStreamUrl = "https:" + gogoAnimePageDocument.getElementsByClass("play-video").get(0).getElementsByTag("iframe").get(0).attr("src");
-            String vidCdnUrl = vidStreamUrl.replace("streaming.php", "loadserver.php");
-
             String m3u8Link = "";
+            String htmlToParse = "";
+            String vidCdnUrl = vidStreamUrl;
             Document vidCdnPageDocument = Jsoup.connect(vidCdnUrl).get();
             Log.i("vidcdn", "vidcdn is " + vidCdnUrl);
-            String htmlToParse = vidCdnPageDocument.outerHtml();
+            htmlToParse = vidCdnPageDocument.outerHtml();
             // Log.i("m3u8html",htmlToParse);
             Matcher matcher = urlPattern.matcher(htmlToParse);
 


### PR DESCRIPTION
This PR fixes the following issues:

Quality names for fallbacks were not descriptive for users; they will now say 'No other qualities available'

Videos with working m3u8 links were falling back to webview player with ads because of a change in format; this is fixed

Next video button would cause errors on some playlists (and still might altough there should be much less of this).

A third option was added for the webview fallback / last check for m3u8. Priorities were fixed. Headers support was added to resolve some issues gaining access to m3u8 playlists.

(Sorry about the messy second commit, I needed to rebase)